### PR TITLE
API bump

### DIFF
--- a/NPC-Plugin-Chooser/BSAHandler.cs
+++ b/NPC-Plugin-Chooser/BSAHandler.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Mutagen.Bethesda;
 using System.IO;
+using Mutagen.Bethesda.Archives;
+using Mutagen.Bethesda.Plugins;
 
 namespace NPCPluginChooser
 {
@@ -48,7 +50,7 @@ namespace NPCPluginChooser
                 try
                 {
                     var fileStream = File.Create(destPath);
-                    file.CopyDataTo(fileStream);
+                    file.AsStream().CopyTo(fileStream);
                 }
                 catch
                 {

--- a/NPC-Plugin-Chooser/NPC-Plugin-Chooser.csproj
+++ b/NPC-Plugin-Chooser/NPC-Plugin-Chooser.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mutagen.Bethesda" Version="0.29.2" />
-    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.18.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="niflysharp" Version="1.1.0" />
+    <PackageReference Include="Mutagen.Bethesda" Version="0.30.1" />
+    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.19.0" />
+    <PackageReference Include="niflysharp" Version="1.2.3" />
   </ItemGroup>
 </Project>

--- a/NPC-Plugin-Chooser/Program.cs
+++ b/NPC-Plugin-Chooser/Program.cs
@@ -6,12 +6,16 @@ using Mutagen.Bethesda.Synthesis;
 using Mutagen.Bethesda.Skyrim;
 using System.Threading.Tasks;
 using System.IO;
+using Mutagen.Bethesda.Archives;
 using NPCPluginChooser.Settings;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Converters;
 using Noggog.Utility;
 using Mutagen.Bethesda.Json;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Cache;
+using Noggog;
 
 namespace NPCPluginChooser
 {
@@ -535,14 +539,14 @@ namespace NPCPluginChooser
 
                     if (meshFound == false && BSAHandler.HaveFile(BSAmeshPath, currentContextReaders, out var archiveMeshFile) && archiveMeshFile != null)
                     {
-                        archiveMeshFile.CopyDataTo(NifStream);
+                        archiveMeshFile.AsStream().CopyTo(NifStream);
                         meshFound = true;
                         NifBSAWinner = context.ModKey;
                     }
 
                     if (texFound == false && BSAHandler.HaveFile(BSAtexPath, currentContextReaders, out var archiveTexFile) && archiveTexFile != null)
                     {
-                        archiveTexFile.CopyDataTo(DdsStream);
+                        archiveTexFile.AsStream().CopyTo(DdsStream);
                         texFound = true;
                         DdsBSAWinner = context.ModKey;
                     }

--- a/NPC-Plugin-Chooser/Settings/PatcherSettings.cs
+++ b/NPC-Plugin-Chooser/Settings/PatcherSettings.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Noggog;
 using Mutagen.Bethesda.Synthesis.Settings;
 using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;


### PR DESCRIPTION
Main break is IArchive no longer exposes CopyDataTo.  Instead if just exposes GetBytes/GetStream for more general use.

The change I made is the least invasive, but there's might be better ways to refactor it.  (eg, could just use the stream directly instead of copying it into your own temp stream, maybe?)   Didnt want to muck around too much, though